### PR TITLE
Fix config and pause bug

### DIFF
--- a/cogs/music_player.py
+++ b/cogs/music_player.py
@@ -657,12 +657,14 @@ class MusicPlayer(commands.Cog):
 
         try:
             if bot_voice_state.is_playing():
-                bot_voice_state._pause()
+                bot_voice_state.pause()
+                self._pause()
                 await interaction.response.send_message("Paused the song.", ephemeral=True)
                 if self.update_progress_loop.is_running():
                     self.update_progress_loop.stop()
             elif bot_voice_state.is_paused():
                 bot_voice_state.resume()
+                self.resume()
                 await interaction.response.send_message("Resumed the song.", ephemeral=True)
                 if not self.update_progress_loop.is_running():
                     self.update_progress_loop.start()

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from discord.ext.commands import is_owner, Context
 
 # Load environment variables
-load_dotenv("config.env.txt")
+load_dotenv("config.env")
 
 DISCORD_TOKEN = os.getenv('DISCORD_TOKEN')
 DISCORD_PREFIX = "%"


### PR DESCRIPTION
## Summary
- fix environment file path in config
- correct the pause command logic to use `pause()` and track playback time

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68417f04b00883239c281f9549a21570